### PR TITLE
Fixes grammar for output on wp-config.php.

### DIFF
--- a/lib/rules/wp-login.js
+++ b/lib/rules/wp-login.js
@@ -42,9 +42,9 @@ exports.fire = ( data ) => {
         }
 
         if ( response.request.uri.protocol !== 'https:' ) {
-            log.info( `${targetURL} is not use HTTPS protocol`, logObj )
+            log.info( `${targetURL} doesn't use HTTPS protocol`, logObj )
         } else {
-            log.ok( `${targetURL} use HTTPS protocol`, logObj )
+            log.ok( `${targetURL} uses HTTPS protocol`, logObj )
         }
 
         if ( ! [401, 403].includes( response.statusCode ) ) {


### PR DESCRIPTION
To my understanding the currently used output `${targetURL} is not use HTTPS` and `${targetURL} use HTTPS protocol` are grammatically wrong. I corrected the grammar in this pull request.